### PR TITLE
update deprecated boost url

### DIFF
--- a/org.wesnoth.Wesnoth.json
+++ b/org.wesnoth.Wesnoth.json
@@ -28,7 +28,7 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.tar.bz2",
+          "url": "https://archives.boost.io/release/1.80.0/source/boost_1_80_0.tar.bz2",
           "sha256": "1e19565d82e43bc59209a168f5ac899d3ba471d55c7610c677d4ccf2c9c500c0"
         }
       ],


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
